### PR TITLE
Improve module hygiene and add a `temp` utility

### DIFF
--- a/Device/TotalConnectComfort.pm
+++ b/Device/TotalConnectComfort.pm
@@ -1,9 +1,6 @@
-#!/usr/bin/perl
-
+package Device::TotalConnectComfort;
 use warnings;
 use strict;
-
-package Device::TotalConnectComfort;
 
 use Carp;
 use Data::Dumper;
@@ -11,11 +8,8 @@ use JSON;
 use LWP::UserAgent;
 use URI::Escape qw( uri_escape );
 
-use base qw( Exporter );
-our @EXPORT_OK = qw( new );
-
 my $DEBUG = 0;
-$\ = "\n";
+local $\ = "\n";
 
 my $BASE_PATH = '/WebAPI/emea/api/v1/';
 

--- a/temp
+++ b/temp
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+use v5.14;
+use open qw( :encoding(UTF-8) :std);
+
+use Cwd qw(abs_path);
+use File::Basename qw(dirname basename);
+BEGIN {
+	use lib dirname(abs_path($0));
+}
+
+use Device::TotalConnectComfort;
+use Config::Tiny;
+use DateTime;
+
+my ($temp, $duration) = @ARGV;
+$duration ||= "";
+
+my $dt = DateTime->now(time_zone => "local");
+if($duration =~ /^(\d+) seconds?$/) {
+	$dt->add(seconds => $1);
+} elsif($duration =~ /^(\d+) minutes?$/) {
+	$dt->add(minutes => $1);
+} elsif($duration =~ /^(\d+) hours?$/) {
+	$dt->add(hours => $1);
+} elsif($duration =~ /^\+(\d+):(\d+)(?::(\d+))?$/) {
+	$dt->add(hours => $1, minutes => $2);
+	if($3) {
+		$dt->add(seconds => $3);
+	}
+} elsif($duration =~ /^(\d+):(\d+)(?::(\d+))?$/) {
+	my $dt_old = $dt->clone();
+	$dt->set_hour($1);
+	$dt->set_minute($2);
+	$dt->set_second($3 || 0);
+	if($dt < $dt_old) {
+		$dt->add(days => 1);
+	}
+} else {
+	my $bn = basename($0);
+	warn "Usage: $bn <temp> <duration>\n\n";
+	warn "Examples:\n";
+	warn "  $bn 22.0 \"2 hours\" - set temperature to 22.0\xb0C for the next 2 hours\n";
+	warn "  $bn 18.5 +00:30    - set temperature to 18.5\xb0C for the next 30 minutes\n";
+	warn "  $bn 23 22:00       - set temperature to 23.0\xb0C until 22:00\n";
+	exit(1);
+}
+
+my $config = Config::Tiny->read($ENV{HOME} . "/.tccrc");
+if(!$config) {
+	print "No configuration found. Write the following to your ~/.tccrc:\n";
+	print "  username=...\n";
+	print "  password=...\n";
+	print "Fill in the values, then try again.\n";
+	exit 1;
+}
+my $username = $config->{_}{'username'};
+my $password = $config->{_}{'password'};
+
+my $cn = Device::TotalConnectComfort->new(username => $username, password => $password);
+my $location = $cn->get_locations->[0];
+my $location_id = $location->{locationInfo}{locationId};
+my $zone_id = $location->{'gateways'}[0]{'temperatureControlSystems'}[0]{'zones'}[0]{'zoneId'};
+
+$dt->set_time_zone('UTC');
+my $setpoind_id = $cn->set_heat_setpoint($zone_id, $temp, "TemporaryOverride", $dt->iso8601 . 'Z');
+
+$dt->set_time_zone('local');
+print "Temperature set to ${temp}\xb0C until " . $dt->hms . "\n";

--- a/temp
+++ b/temp
@@ -38,13 +38,14 @@ if($duration =~ /^(\d+) seconds?$/) {
 	if($dt < $dt_old) {
 		$dt->add(days => 1);
 	}
-} else {
+} elsif($temp ne "-") {
 	my $bn = basename($0);
 	warn "Usage: $bn <temp> <duration>\n\n";
 	warn "Examples:\n";
 	warn "  $bn 22.0 \"2 hours\" - set temperature to 22.0\xb0C for the next 2 hours\n";
 	warn "  $bn 18.5 +00:30    - set temperature to 18.5\xb0C for the next 30 minutes\n";
 	warn "  $bn 23 22:00       - set temperature to 23.0\xb0C until 22:00\n";
+	warn "  $bn -              - cancel temporary temperature change\n";
 	exit(1);
 }
 
@@ -64,8 +65,13 @@ my $location = $cn->get_locations->[0];
 my $location_id = $location->{locationInfo}{locationId};
 my $zone_id = $location->{'gateways'}[0]{'temperatureControlSystems'}[0]{'zones'}[0]{'zoneId'};
 
-$dt->set_time_zone('UTC');
-my $setpoind_id = $cn->set_heat_setpoint($zone_id, $temp, "TemporaryOverride", $dt->iso8601 . 'Z');
+if($temp eq "-") {
+	$cn->set_heat_setpoint($zone_id, 0, "FollowSchedule");
+	print "Temporary temperature cancelled.\n";
+} else {
+	$dt->set_time_zone('UTC');
+	$cn->set_heat_setpoint($zone_id, $temp, "TemporaryOverride", $dt->iso8601 . 'Z');
 
-$dt->set_time_zone('local');
-print "Temperature set to ${temp}\xb0C until " . $dt->hms . "\n";
+	$dt->set_time_zone('local');
+	print "Temperature set to ${temp}\xb0C until " . $dt->hms . "\n";
+}

--- a/test_api.pl
+++ b/test_api.pl
@@ -6,7 +6,7 @@ use strict;
 use Data::Dumper;
 use Text::Table;
 
-use Device::TotalConnectComfort qw( new );
+use Device::TotalConnectComfort;
 
 # AUTHENTICATION:
 # This can be passed in via the commandline (beware visible to ps..),
@@ -51,7 +51,7 @@ sub describe_locations {
     print "Found ", scalar @$locations_data, ' ',
       ( scalar @$locations_data == 1 ) ? 'location' : 'locations', "\n";
     for my $location (@$locations_data) {
-        print "Location $location->{locationInfo}->{locationId} ($location->{locationInfo}->{streetAddress})\n---";
+        print "Location $location->{locationInfo}->{locationId} ($location->{locationInfo}->{streetAddress})\n---\n";
         # describe_devices($location);
     }
 }
@@ -83,7 +83,7 @@ sub describe_gateways {
     my $gateway_data = shift;
 
     for my $gw (@$gateway_data) {
-        print "Found gateway ID: $gw->{gatewayId}, MAC address: $gw->{mac}";
+        print "Found gateway ID: $gw->{gatewayId}, MAC address: $gw->{mac}\n";
     }
 }
 


### PR DESCRIPTION
- Enable warnings/strict inside the module, instead of outside
- Don't clobber $\, so the module can be used in existing code without changing how print works
- Don't export new: this only allows calling 'new' as a free function, which clobbers the global namespace; you don't need to export for `Device::TotalConnectComfort->new(...)` to work.

I've also added a handy utility called `temp`, that (when placed in `$PATH`) will allow very easy temporary changing of the thermostat setting. If you don't want that tool, feel free to merge only commit 8564521.
